### PR TITLE
Display recent posts on landing page

### DIFF
--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -1,5 +1,13 @@
 ---
+import { getCollection, type CollectionEntry } from 'astro:content';
+
 // Based on uploaded HTML landing content
+const allPosts: CollectionEntry<'blog'>[] = await getCollection('blog');
+allPosts.sort(
+  (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+    b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+);
+const posts = allPosts.slice(0, 3);
 ---
 
       <div class="container">
@@ -100,6 +108,23 @@
                           <p>Specialized experience working with Department of Defense clients and government agencies, ensuring compliance with security requirements while delivering innovative AI solutions that meet mission-critical objectives.</p>
                       </div>
                   </div>
+              </section>
+
+              <section class="section">
+                  <h2>Recent Posts</h2>
+                  <ul>
+                    {posts.map((post) => (
+                      <li>
+                        <a href={`/blog/${post.slug}/`}>{post.data.title}</a>
+                        <p>{post.data.description}</p>
+                        <p>
+                          <time datetime={post.data.publishDate.toISOString()}>
+                            {post.data.publishDate.toDateString()}
+                          </time>
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
               </section>
           </main>
 

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,16 +1,16 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts: CollectionEntry<'blog'>[] = await getCollection('blog');
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post },
   }));
 }
 
-const { post } = Astro.props;
+const { post } = Astro.props as { post: CollectionEntry<'blog'> };
 const { Content } = await post.render();
 const { title, description, publishDate, author } = post.data;
 ---

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,9 +1,11 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, type CollectionEntry } from 'astro:content';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+const posts: CollectionEntry<'blog'>[] = await getCollection('blog');
+posts.sort(
+  (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+    b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
 );
 ---
 


### PR DESCRIPTION
## Summary
- surface latest blog posts on landing page
- add type annotations to blog pages to satisfy Astro checks

## Testing
- `npm test`
- `npm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68910cc2c75483338d3bc11627be5d39