### PR TITLE
chore: add vitest for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
     "@astrojs/check": "^0.9.4",
     "astro": "^5.12.8",
     "typescript": "^5.9.2"
+  },
+  "devDependencies": {
+    "vitest": "^1.6.0"
   }
 }

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from 'vitest';
+
+describe('example', () => {
+  it('runs a basic test', () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- install vitest for unit testing
- add an example vitest test

## Testing
- `npm run test:unit` (fails: `sh: 1: vitest: not found`)


------
https://chatgpt.com/codex/tasks/task_e_689114989884833385290b4c71a166a4