### PR TITLE
feat: improve blog post layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,6 +7,8 @@ import "../styles/global.css";
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <body>
-    <slot />
+    <main class="container">
+      <slot />
+    </main>
   </body>
 </html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -15,11 +15,11 @@ const { Content } = await post.render();
 const { title, description, publishDate, author } = post.data;
 ---
 
-<BaseLayout>
-  <article>
-    <h1>{title}</h1>
-    <p>{description}</p>
-    <p><time datetime={publishDate.toISOString()}>{publishDate.toDateString()}</time> • {author}</p>
-    <Content />
-  </article>
-</BaseLayout>
+  <BaseLayout>
+    <article class="post">
+      <h1>{title}</h1>
+      <p class="post-description">{description}</p>
+      <p class="post-meta"><time datetime={publishDate.toISOString()}>{publishDate.toDateString()}</time> • {author}</p>
+      <Content />
+    </article>
+  </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -9,8 +9,7 @@ posts.sort(
 );
 ---
 
-<BaseLayout>
-  <main>
+  <BaseLayout>
     <h1>Blog</h1>
     <ul>
       {posts.map((post) => (
@@ -25,5 +24,4 @@ posts.sort(
         </li>
       ))}
     </ul>
-  </main>
-</BaseLayout>
+  </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Landing from '../components/Landing.astro';
 ---
 
-<BaseLayout>
-  <main>
+  <BaseLayout>
     <Landing />
-  </main>
-</BaseLayout>
+  </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -18,3 +18,28 @@ a {
   margin: 0 auto;
   padding: 2rem;
 }
+
+/* Blog post styling */
+.post {
+  max-width: 800px;
+  margin: 0 auto;
+  background-color: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.post h1 {
+  margin-top: 0;
+}
+
+.post-description {
+  font-size: 1.25rem;
+  color: #555;
+}
+
+.post-meta {
+  font-size: 0.875rem;
+  color: #888;
+  margin-bottom: 2rem;
+}


### PR DESCRIPTION
## Summary
- center site content using a container in BaseLayout
- style blog posts with a card-like layout and metadata styling
- remove redundant main wrappers on pages

## Testing
- `npm test`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_689118b83f4c8333823f7d207e8460a6