### PR TITLE
feat: add blog index page

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,10 +1,19 @@
 ---
 import "../styles/global.css";
+
+export interface Props {
+  title?: string;
+  description?: string;
+}
+
+const { title = "Pouya Data", description } = Astro.props as Props;
 ---
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
   </head>
   <body>
     <main class="container">

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -5,23 +5,24 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 const posts: CollectionEntry<'blog'>[] = await getCollection('blog');
 posts.sort(
   (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
-    b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+    b.data.publishDate.valueOf() - a.data.publishDate.valueOf(),
 );
 ---
-
-  <BaseLayout>
-    <h1>Blog</h1>
-    <ul>
-      {posts.map((post) => (
-        <li>
-          <a href={`/blog/${post.slug}/`}>{post.data.title}</a>
+<BaseLayout title="Blog" description="Browse all blog posts from Pouya Data">
+  <h1>Blog</h1>
+  <ul>
+    {posts.map((post) => (
+      <li>
+        <article>
+          <h2><a href={`/blog/${post.slug}/`}>{post.data.title}</a></h2>
           <p>{post.data.description}</p>
           <p>
             <time datetime={post.data.publishDate.toISOString()}>
               {post.data.publishDate.toDateString()}
             </time>
           </p>
-        </li>
-      ))}
-    </ul>
-  </BaseLayout>
+        </article>
+      </li>
+    ))}
+  </ul>
+</BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Landing from '../components/Landing.astro';
 ---
 
-  <BaseLayout>
-    <Landing />
-  </BaseLayout>
+<BaseLayout title="Home" description="Pouya Data blog and resources">
+  <Landing />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add dedicated blog index that lists all posts
- allow setting page titles and descriptions through BaseLayout

## Testing
- `npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68911b5aa01c83338fa80c50b1de6ebc