### PR TITLE
ci: run tests before build

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
         working-directory: ${{ env.BUILD_PATH }}
+      - name: Run tests
+        run: npm test
+        working-directory: ${{ env.BUILD_PATH }}
+      - name: Run unit tests
+        run: npm run test:unit
+        working-directory: ${{ env.BUILD_PATH }}
       - name: Build with Astro
         run: |
           ${{ steps.detect-package-manager.outputs.runner }} astro build \


### PR DESCRIPTION
## Summary
- run `npm test` and `npm run test:unit` before building

## Testing
- `npm test`
- `CI=1 npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_689128f33a9c8333a69bc274c96836d6