### PR TITLE
feat: extract post list component

### DIFF
--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -1,4 +1,5 @@
 ---
+import PostList from './PostList.astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
 
 // Based on uploaded HTML landing content
@@ -112,19 +113,7 @@ const posts = allPosts.slice(0, 3);
 
               <section class="section">
                   <h2>Recent Posts</h2>
-                  <ul>
-                    {posts.map((post) => (
-                      <li>
-                        <a href={`/blog/${post.slug}/`}>{post.data.title}</a>
-                        <p>{post.data.description}</p>
-                        <p>
-                          <time datetime={post.data.publishDate.toISOString()}>
-                            {post.data.publishDate.toDateString()}
-                          </time>
-                        </p>
-                      </li>
-                    ))}
-                  </ul>
+                  <PostList posts={posts} />
               </section>
           </main>
 

--- a/src/components/PostList.astro
+++ b/src/components/PostList.astro
@@ -1,0 +1,21 @@
+---
+import type { CollectionEntry } from 'astro:content';
+const { posts } = Astro.props as { posts: CollectionEntry<'blog'>[] };
+---
+
+<ul>
+  {posts.map((post) => (
+    <li>
+      <article>
+        <h2><a href={`/blog/${post.slug}/`}>{post.data.title}</a></h2>
+        <p>{post.data.description}</p>
+        <p>
+          <time datetime={post.data.publishDate.toISOString()}>
+            {post.data.publishDate.toDateString()}
+          </time>
+        </p>
+      </article>
+    </li>
+  ))}
+</ul>
+

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostList from '../../components/PostList.astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
 
 const posts: CollectionEntry<'blog'>[] = await getCollection('blog');
@@ -10,19 +11,5 @@ posts.sort(
 ---
 <BaseLayout title="Blog" description="Browse all blog posts from Pouya Data">
   <h1>Blog</h1>
-  <ul>
-    {posts.map((post) => (
-      <li>
-        <article>
-          <h2><a href={`/blog/${post.slug}/`}>{post.data.title}</a></h2>
-          <p>{post.data.description}</p>
-          <p>
-            <time datetime={post.data.publishDate.toISOString()}>
-              {post.data.publishDate.toDateString()}
-            </time>
-          </p>
-        </article>
-      </li>
-    ))}
-  </ul>
+  <PostList posts={posts} />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add reusable `PostList` component for rendering blog entries
- replace inline post loops in landing page and blog index with `PostList`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689128ea3c0c8333927b74f3d33dc4a0