### PR TITLE
Add global navigation component

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,0 +1,5 @@
+---
+---
+<nav class="site-nav">
+  <a href="/">Home</a> / <a href="/blog">Blog</a>
+</nav>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import Nav from "../components/Nav.astro";
 
 export interface Props {
   title?: string;
@@ -16,6 +17,7 @@ const { title = "Pouya Data", description } = Astro.props as Props;
     {description && <meta name="description" content={description} />}
   </head>
   <body>
+    <Nav />
     <main class="container">
       <slot />
     </main>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -16,9 +16,6 @@ const { title, description, publishDate, author } = post.data;
 ---
 
   <BaseLayout>
-    <nav class="post-nav">
-      <a href="/">Home</a> / <a href="/blog">All Posts</a>
-    </nav>
     <article class="post">
       <h1>{title}</h1>
       <p class="post-description">{description}</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,11 +13,11 @@ a {
   text-decoration: none;
 }
 
-.post-nav {
+.site-nav {
   margin-bottom: 1rem;
 }
 
-.post-nav a {
+.site-nav a {
   margin-right: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Add `Nav.astro` with links to Home and Blog
- Include Nav component in `BaseLayout` so navigation appears globally
- Remove outdated per-post navigation and update global styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689128d7d9608333945bf4a29bb6f4ca