### PR TITLE
feat: surface post metadata in blog layout

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -15,7 +15,7 @@ const { Content } = await post.render();
 const { title, description, publishDate, author } = post.data;
 ---
 
-  <BaseLayout>
+  <BaseLayout title={title} description={description}>
     <article class="post">
       <h1>{title}</h1>
       <p class="post-description">{description}</p>


### PR DESCRIPTION
## Summary
- pass each blog post's `title` and `description` to `BaseLayout` so metadata is injected into `<head>`

## Testing
- `npm test`
- `CI=1 npm run test:unit -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68916532cf748333884726037c79022f