### PR TITLE
Refactor landing summary into paragraphs

### DIFF
--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -18,14 +18,23 @@ const posts = allPosts.slice(0, 3);
 <div class="container">
   <Header />
   <main class="main-content">
-    <section class="section">
-      <h2>Executive Summary</h2>
-      <div class="summary">
-        As the landscape of technology rapidly evolves, harnessing the power of Data Science, Machine Learning, and Generative AI has become essential for organizations aiming to lead in innovation. With over two decades of experience driving transformative technology initiatives, I specialize in empowering organizations to unlock the full potential of their data assets and AI capabilities.
-        <br><br>
-        My expertise bridges the gap between cutting-edge theoretical concepts and practical, actionable implementations that deliver measurable business value. From strategic consulting to hands-on implementation, I guide organizations through their complete AI transformation journey.
-      </div>
-    </section>
+      <section class="section">
+        <h2>Executive Summary</h2>
+        <p class="summary">
+          As the landscape of technology rapidly evolves, harnessing the power of
+          Data Science, Machine Learning, and Generative AI has become essential
+          for organizations aiming to lead in innovation. With over two decades
+          of experience driving transformative technology initiatives, I
+          specialize in empowering organizations to unlock the full potential of
+          their data assets and AI capabilities.
+        </p>
+        <p class="summary">
+          My expertise bridges the gap between cutting-edge theoretical concepts
+          and practical, actionable implementations that deliver measurable
+          business value. From strategic consulting to hands-on implementation, I
+          guide organizations through their complete AI transformation journey.
+        </p>
+      </section>
     <Capabilities />
     <RecentPosts posts={posts} />
   </main>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -135,6 +135,11 @@ body {
     padding: 40px;
     border-radius: 20px;
     border-left: 5px solid #2a5298;
+    margin-bottom: 20px;
+}
+
+.summary:last-of-type {
+    margin-bottom: 0;
 }
 
 .capabilities-grid {


### PR DESCRIPTION
## Summary
- replace summary div with paragraph elements and remove `<br>` tags
- add spacing rules for summary paragraphs in `landing.css`

## Testing
- `npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_689167b3d56483338ad2c539c1deb364