### PR TITLE
refactor: extract technologies heading styles

### DIFF
--- a/src/components/Technologies.astro
+++ b/src/components/Technologies.astro
@@ -1,7 +1,7 @@
 ---
 ---
 <section class="technologies">
-  <h2 style="text-align: center; color: white; border-bottom: 3px solid #FFD700;">Technology Expertise</h2>
+  <h2 class="tech-heading">Technology Expertise</h2>
   <div class="tech-grid">
     <div class="tech-category">
       <h4>AI & Machine Learning</h4>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -202,6 +202,12 @@ body {
     margin-top: 40px;
 }
 
+.tech-heading {
+    text-align: center;
+    color: white;
+    border-bottom: 3px solid #FFD700;
+}
+
 .tech-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- replace inline styles on technologies heading with `tech-heading` class
- define `.tech-heading` in `landing.css`

## Testing
- `npm test`
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689167b056f8833383eacd7fa150decf