### PR TITLE
Refactor header contact links

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,4 +1,22 @@
 ---
+const contactSections = [
+  {
+    role: "Chief Technology Officer",
+    contacts: [
+      { site: "tequity.app", email: "pouya@tequity.app" },
+      { site: "kenniss.com", email: "pouya@kenniss.com" },
+    ],
+  },
+  {
+    role: "Chief Data & AI Officer",
+    contacts: [
+      { site: "cervais.com", email: "pouya@cervais.com" },
+      { site: "bookerdimaio.com", email: "pouya.byousefi@bookerdimaio.com" },
+      { site: "pouyadata.com", email: "pouyadatallc@gmail.com" },
+      { site: "humanrightsconnected.org", email: "pouya@humanrightsconnected.org" },
+    ],
+  },
+];
 ---
 <header class="header">
   <div class="header-content">
@@ -8,42 +26,17 @@
       <div class="tagline">Transforming Organizations Through Data Science, Machine Learning, and Generative AI Innovation</div>
     </div>
     <div class="contact-grid">
-      <div class="contact-info">
-        <div class="role-title">Chief Technology Officer</div>
-        <div class="contact-line">
-          <span>🌐 tequity.app</span>
-          <span>|</span>
-          <span>📧 pouya@tequity.app</span>
+      {contactSections.map((section) => (
+        <div class="contact-info">
+          <div class="role-title">{section.role}</div>
+          {section.contacts.map((contact) => (
+            <ul class="contact-line">
+              <li>🌐 <a href={`https://${contact.site}`}>{contact.site}</a></li>
+              <li>📧 <a href={`mailto:${contact.email}`}>{contact.email}</a></li>
+            </ul>
+          ))}
         </div>
-        <div class="contact-line">
-          <span>🌐 kenniss.com</span>
-          <span>|</span>
-          <span>📧 pouya@kenniss.com</span>
-        </div>
-      </div>
-      <div class="contact-info">
-        <div class="role-title">Chief Data & AI Officer</div>
-        <div class="contact-line">
-          <span>🌐 cervais.com</span>
-          <span>|</span>
-          <span>📧 pouya@cervais.com</span>
-        </div>
-        <div class="contact-line">
-          <span>🌐 bookerdimaio.com</span>
-          <span>|</span>
-          <span>📧 pouya.byousefi@bookerdimaio.com</span>
-        </div>
-        <div class="contact-line">
-          <span>🌐 pouyadata.com</span>
-          <span>|</span>
-          <span>📧 pouyadatallc@gmail.com</span>
-        </div>
-        <div class="contact-line">
-          <span>🌐 humanrightsconnected.org</span>
-          <span>|</span>
-          <span>📧 pouya@humanrightsconnected.org</span>
-        </div>
-      </div>
+      ))}
     </div>
   </div>
 </header>

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -97,7 +97,9 @@ body {
 
 .contact-line {
     font-size: 0.9em;
-    margin-bottom: 5px;
+    margin: 0 0 5px 0;
+    padding: 0;
+    list-style: none;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Summary
- map header contact info through data structure to avoid manual markup
- link URLs and emails, use list semantics instead of pipes
- reset list styling for contact lines

## Testing
- `npm test`
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_689167ac040483339f55fd638892b68f