### PR TITLE
Add component tests for blog posts and update testing setup

### DIFF
--- a/src/blog-sort.test.ts
+++ b/src/blog-sort.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+
+describe('blog sorting', () => {
+  it('orders posts by publish date descending', () => {
+    const posts = [
+      { slug: 'old', data: { publishDate: new Date('2023-01-01') } },
+      { slug: 'new', data: { publishDate: new Date('2024-01-01') } },
+    ];
+    posts.sort(
+      (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+    );
+    expect(posts.map((p) => p.slug)).toEqual(['new', 'old']);
+  });
+});

--- a/src/components/PostList.test.ts
+++ b/src/components/PostList.test.ts
@@ -2,10 +2,24 @@ import { describe, it, expect } from 'vitest';
 import { renderAstro } from '../test-utils';
 
 describe('PostList', () => {
-  it('renders posts in given order with correct links', async () => {
+  it('renders posts with details in given order', async () => {
     const posts = [
-      { slug: 'first', data: { title: 'First', description: 'Desc1', publishDate: new Date('2023-01-01') } },
-      { slug: 'second', data: { title: 'Second', description: 'Desc2', publishDate: new Date('2024-01-01') } },
+      {
+        slug: 'first',
+        data: {
+          title: 'First',
+          description: 'Desc1',
+          publishDate: new Date('2023-01-01'),
+        },
+      },
+      {
+        slug: 'second',
+        data: {
+          title: 'Second',
+          description: 'Desc2',
+          publishDate: new Date('2024-01-01'),
+        },
+      },
     ];
     const html = await renderAstro('src/components/PostList.astro', { posts });
     const firstIndex = html.indexOf('href="/blog/first/"');
@@ -13,5 +27,9 @@ describe('PostList', () => {
     expect(firstIndex).toBeLessThan(secondIndex);
     expect(html).toContain('<a href="/blog/first/">First</a>');
     expect(html).toContain('<a href="/blog/second/">Second</a>');
+    expect(html).toContain('Desc1');
+    expect(html).toContain('Desc2');
+    expect(html).toContain(posts[0].data.publishDate.toDateString());
+    expect(html).toContain(posts[1].data.publishDate.toDateString());
   });
 });

--- a/src/example.test.ts
+++ b/src/example.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('example', () => {
-  it('runs a basic test', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,10 +1,9 @@
-import { readFile, writeFile } from 'fs/promises';
-import fs from 'fs';
+import { readFile, writeFile, unlink } from 'node:fs/promises';
 import { transform } from '@astrojs/compiler';
 import * as runtime from 'astro/runtime/server/index.js';
-import path from 'path';
-import { randomUUID } from 'crypto';
-import { pathToFileURL } from 'url';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
 
 export async function renderAstro(
   file: string,
@@ -25,7 +24,7 @@ export async function renderAstro(
   const tempPath = path.join(path.dirname(file), `.tmp-${randomUUID()}.mjs`);
   await writeFile(tempPath, code, 'utf-8');
   const mod = await import(pathToFileURL(tempPath).href);
-  await fs.promises?.unlink?.(tempPath).catch(() => {});
+  await unlink(tempPath).catch(() => {});
   const Component = mod.default;
   const result = {
     _metadata: { hasRenderedHead: false, extraHead: [] },
@@ -60,6 +59,6 @@ export async function renderAstro(
     componentMetadata: new Map(),
     inlinedScripts: new Map(),
   } as any;
-  const html = await runtime.renderToString(result, Component, props, {});
-  return html;
-}
+    const html = (await runtime.renderToString(result, Component, props, {})) as string;
+    return html;
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "baseUrl": ".",
+    "moduleResolution": "bundler",
+    "types": ["vitest"],
     "paths": {
       "~/*": ["src/*"]
     }


### PR DESCRIPTION
## Summary
- test PostList component rendering, including descriptions and dates
- add unit test for blog post sorting
- modernize test utilities and TypeScript config

## Testing
- `npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_689173de43a48333a233f45c8abff6a3