### PR TITLE
refactor: centralize blog post sorting

### DIFF
--- a/src/blog-sort.test.ts
+++ b/src/blog-sort.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { sortPostsByDateDesc } from '~/utils/post';
 
 describe('blog sorting', () => {
   it('orders posts by publish date descending', () => {
@@ -6,9 +7,9 @@ describe('blog sorting', () => {
       { slug: 'old', data: { publishDate: new Date('2023-01-01') } },
       { slug: 'new', data: { publishDate: new Date('2024-01-01') } },
     ];
-    posts.sort(
-      (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
-    );
-    expect(posts.map((p) => p.slug)).toEqual(['new', 'old']);
+    expect(sortPostsByDateDesc(posts).map((p) => p.slug)).toEqual([
+      'new',
+      'old',
+    ]);
   });
 });

--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -5,15 +5,11 @@ import RecentPosts from '~/components/RecentPosts.astro';
 import Technologies from '~/components/Technologies.astro';
 import CTA from '~/components/CTA.astro';
 import '~/styles/landing.css';
-import { getCollection, type CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+import { sortPostsByDateDesc } from '~/utils/post';
 
 // Based on uploaded HTML landing content
-const allPosts: CollectionEntry<'blog'>[] = await getCollection('blog');
-allPosts.sort(
-  (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
-    b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
-);
-const posts = allPosts.slice(0, 3);
+const posts = sortPostsByDateDesc(await getCollection('blog')).slice(0, 3);
 ---
 <div class="container">
   <Header />

--- a/src/components/Landing.test.ts
+++ b/src/components/Landing.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { sortPostsByDateDesc } from '~/utils/post';
 
 describe('Landing', () => {
   it('orders posts by publish date descending and selects top three', () => {
@@ -8,10 +9,9 @@ describe('Landing', () => {
       { slug: 'mid', data: { publishDate: new Date('2023-06-01') } },
       { slug: 'older', data: { publishDate: new Date('2022-01-01') } },
     ];
-    posts.sort(
-      (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
-    );
-    const selected = posts.slice(0, 3).map((p) => p.slug);
+    const selected = sortPostsByDateDesc(posts)
+      .slice(0, 3)
+      .map((p) => p.slug);
     expect(selected).toEqual(['new', 'mid', 'old']);
   });
 });

--- a/src/utils/post.ts
+++ b/src/utils/post.ts
@@ -1,0 +1,11 @@
+import type { CollectionEntry } from 'astro:content';
+
+export function sortPostsByDateDesc(
+  posts: CollectionEntry<'blog'>[]
+): CollectionEntry<'blog'>[] {
+  return posts.sort(
+    (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+      b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `sortPostsByDateDesc` utility to reuse blog post sorting logic
- use the helper in the Landing component
- update tests to use the shared helper

## Testing
- `npm test`
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6891799d61248333b5fc984184c09b17