### PR TITLE
chore: set up linting and formatting

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:astro/recommended',
+    'prettier',
+  ],
+  overrides: [
+    {
+      files: ['*.astro'],
+      parser: 'astro-eslint-parser',
+      parserOptions: {
+        parser: '@typescript-eslint/parser',
+        extraFileExtensions: ['.astro'],
+      },
+    },
+  ],
+};

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
         working-directory: ${{ env.BUILD_PATH }}
+      - name: Run lint
+        run: npm run lint
+        working-directory: ${{ env.BUILD_PATH }}
       - name: Run tests
         run: npm test
         working-directory: ${{ env.BUILD_PATH }}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-astro"],
+  "pluginSearchDirs": false
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "preview": "astro preview",
     "test": "astro check",
     "test:unit": "vitest",
-    "test:watch": "vitest --watch"
+    "test:watch": "vitest --watch",
+    "lint": "eslint . --ext .ts,.tsx,.astro",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
@@ -15,6 +17,12 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "eslint": "^8.57.0",
+    "prettier": "^3.3.2",
+    "eslint-plugin-astro": "^0.34.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "prettier-plugin-astro": "^0.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint and Prettier configs for Astro/TypeScript
- wire up lint and format npm scripts
- run lint during CI

## Testing
- `npm test`
- `npm run test:unit -- --run`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run format` *(fails: Cannot find package 'prettier-plugin-astro')*


------
https://chatgpt.com/codex/tasks/task_e_68917e7c1a388333a4960e0594cdddf5