### PR TITLE
test: use cheerio for PostList

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "typescript": "^5.9.2"
       },
       "devDependencies": {
+        "cheerio": "^1.0.0",
         "vitest": "^3.2.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
+    "cheerio": "^1.0.0",
     "vitest": "^3.2.4"
   }
 }

--- a/src/components/PostList.test.ts
+++ b/src/components/PostList.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderAstro } from '~/test-utils';
+import { load } from 'cheerio';
 
 describe('PostList', () => {
   it('renders posts with details in given order', async () => {
@@ -21,15 +22,15 @@ describe('PostList', () => {
         },
       },
     ];
-    const html = await renderAstro('src/components/PostList.astro', { posts });
-    const firstIndex = html.indexOf('href="/blog/first/"');
-    const secondIndex = html.indexOf('href="/blog/second/"');
-    expect(firstIndex).toBeLessThan(secondIndex);
-    expect(html).toContain('<a href="/blog/first/">First</a>');
-    expect(html).toContain('<a href="/blog/second/">Second</a>');
-    expect(html).toContain('Desc1');
-    expect(html).toContain('Desc2');
-    expect(html).toContain(posts[0].data.publishDate.toDateString());
-    expect(html).toContain(posts[1].data.publishDate.toDateString());
-  });
-});
+      const html = await renderAstro('src/components/PostList.astro', { posts });
+      const $ = load(html);
+      expect($('li').first().find('a').attr('href')).toBe('/blog/first/');
+      expect($('li').eq(1).find('a').attr('href')).toBe('/blog/second/');
+      expect(html).toContain('<a href="/blog/first/">First</a>');
+      expect(html).toContain('<a href="/blog/second/">Second</a>');
+      expect(html).toContain('Desc1');
+      expect(html).toContain('Desc2');
+      expect(html).toContain(posts[0].data.publishDate.toDateString());
+      expect(html).toContain(posts[1].data.publishDate.toDateString());
+      });
+    });


### PR DESCRIPTION
## Summary
- add cheerio as a dev dependency
- check post ordering by querying DOM with cheerio

## Testing
- `npm test` *(fails: Cannot find module 'cheerio')*
- `npm run test:unit` *(fails: Cannot find package 'cheerio')*


------
https://chatgpt.com/codex/tasks/task_e_68917e56e5088333b61ef9ee43dbbdea