### PR TITLE
Run unit tests from npm test

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: ${{ env.BUILD_PATH }}
-      - name: Run unit tests
-        run: npm run test:unit
-        working-directory: ${{ env.BUILD_PATH }}
       - name: Build with Astro
         run: |
           ${{ steps.detect-package-manager.outputs.runner }} astro build \

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "astro check",
+    "test": "astro check && npm run test:unit",
     "test:unit": "vitest",
     "test:watch": "vitest --watch"
   },


### PR DESCRIPTION
## Summary
- run astro check and vitest via `npm test`
- remove separate unit test step in workflow and rely on `npm test`

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68917e7e52848333a8e25a4371f8771b