### PR TITLE
test: verify PostList order using DOM parsing

### DIFF
--- a/src/components/PostList.test.ts
+++ b/src/components/PostList.test.ts
@@ -22,15 +22,19 @@ describe('PostList', () => {
         },
       },
     ];
-      const html = await renderAstro('src/components/PostList.astro', { posts });
-      const $ = load(html);
-      expect($('li').first().find('a').attr('href')).toBe('/blog/first/');
-      expect($('li').eq(1).find('a').attr('href')).toBe('/blog/second/');
-      expect(html).toContain('<a href="/blog/first/">First</a>');
-      expect(html).toContain('<a href="/blog/second/">Second</a>');
-      expect(html).toContain('Desc1');
-      expect(html).toContain('Desc2');
-      expect(html).toContain(posts[0].data.publishDate.toDateString());
-      expect(html).toContain(posts[1].data.publishDate.toDateString());
-      });
-    });
+
+    const html = await renderAstro('src/components/PostList.astro', { posts });
+    const $ = load(html);
+    const slugs = $('li')
+      .map((_i, li) => $(li).find('a').attr('href')?.split('/')[2])
+      .get();
+
+    expect(slugs).toEqual(['first', 'second']);
+    expect(html).toContain('<a href="/blog/first/">First</a>');
+    expect(html).toContain('<a href="/blog/second/">Second</a>');
+    expect(html).toContain('Desc1');
+    expect(html).toContain('Desc2');
+    expect(html).toContain(posts[0].data.publishDate.toDateString());
+    expect(html).toContain(posts[1].data.publishDate.toDateString());
+  });
+});


### PR DESCRIPTION
## Summary
- use cheerio to query PostList markup and assert slug order
- keep existing title and description text assertions

## Testing
- `npm test`
- `npm run test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689181e691d483338b92112fab7692fb