### PR TITLE
test: add nav component test

### DIFF
--- a/src/components/Nav.test.ts
+++ b/src/components/Nav.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { renderAstro } from '~/test-utils';
+import { load } from 'cheerio';
+
+describe('Nav', () => {
+  it('renders navigation links for Home and Blog', async () => {
+    const html = await renderAstro('src/components/Nav.astro');
+    const $ = load(html);
+    const homeLink = $('a[href="/"]');
+    const blogLink = $('a[href="/blog"]');
+    expect(homeLink).toHaveLength(1);
+    expect(homeLink.text()).toBe('Home');
+    expect(blogLink).toHaveLength(1);
+    expect(blogLink.text()).toBe('Blog');
+  });
+});


### PR DESCRIPTION
## Summary
- add Nav component test to verify Home and Blog navigation links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689184346768833387cc6df5abca36a6