### PR TITLE
test: add header component tests

### DIFF
--- a/src/components/Header.test.ts
+++ b/src/components/Header.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { renderAstro } from '~/test-utils';
+import { load } from 'cheerio';
+
+describe('Header', () => {
+  it('renders role titles and contact info', async () => {
+    const html = await renderAstro('src/components/Header.astro');
+    const $ = load(html);
+    const roles = ['Chief Technology Officer', 'Chief Data & AI Officer'];
+    roles.forEach((role) => {
+      expect($('.role-title').text()).toContain(role);
+    });
+    const contacts = [
+      { site: 'tequity.app', email: 'pouya@tequity.app' },
+      { site: 'kenniss.com', email: 'pouya@kenniss.com' },
+      { site: 'cervais.com', email: 'pouya@cervais.com' },
+      { site: 'bookerdimaio.com', email: 'pouya.byousefi@bookerdimaio.com' },
+      { site: 'pouyadata.com', email: 'pouyadatallc@gmail.com' },
+      {
+        site: 'humanrightsconnected.org',
+        email: 'pouya@humanrightsconnected.org',
+      },
+    ];
+    contacts.forEach(({ site, email }) => {
+      expect($(`a[href=\"https://${site}\"]`).text()).toBe(site);
+      expect($(`a[href=\"mailto:${email}\"]`).text()).toBe(email);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for Header component verifying role titles and contact info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891843647e88333a8fd5d907c2b7808