### PR TITLE
chore: run astro check and unit tests via npm test

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run lint
         run: npm run lint
         working-directory: ${{ env.BUILD_PATH }}
-      - name: Run tests
+      - name: Run checks and tests
         run: npm test
         working-directory: ${{ env.BUILD_PATH }}
       - name: Build with Astro

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "test": "astro check && npm run test:unit",
-    "test:unit": "vitest",
+    "check": "astro check",
+    "test": "npm run check && npm run test:unit",
+    "test:unit": "vitest run",
     "test:watch": "vitest --watch",
     "lint": "eslint . --ext .ts,.tsx,.astro",
     "format": "prettier --write ."


### PR DESCRIPTION
## Summary
- run Astro's type check and vitest together through `npm test`
- rename CI workflow step to reflect combined checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891843e006c83338585abcdee8fb3b9