### PR TITLE
Add tests for RecentPosts component

### DIFF
--- a/src/components/RecentPosts.test.ts
+++ b/src/components/RecentPosts.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderAstro } from '~/test-utils';
+
+const posts = vi.hoisted(() => [
+  {
+    slug: 'first',
+    data: {
+      title: 'First',
+      description: 'Desc1',
+      publishDate: new Date('2023-01-01'),
+    },
+  },
+  {
+    slug: 'second',
+    data: {
+      title: 'Second',
+      description: 'Desc2',
+      publishDate: new Date('2024-01-01'),
+    },
+  },
+]);
+
+const postListStub = vi.hoisted(() => vi.fn((..._args: unknown[]) => ''));
+
+vi.mock('~/components/PostList.astro', () => {
+  (postListStub as unknown as { isAstroComponentFactory: boolean }).isAstroComponentFactory = true;
+  return { default: postListStub };
+});
+
+describe('RecentPosts', () => {
+  it('renders heading and passes posts to PostList', async () => {
+    const html = await renderAstro(
+      'src/components/RecentPosts.astro',
+      { posts },
+      (code) =>
+        code
+          .replace(/interface Props[^}]+}\n/, '')
+          .replace(/ as Props;/, ';')
+    );
+    expect(html).toContain('<h2>Recent Posts</h2>');
+    expect(postListStub).toHaveBeenCalledOnce();
+    expect(postListStub.mock.calls[0][1]).toEqual({ posts });
+  });
+});


### PR DESCRIPTION
## Summary
- test that RecentPosts renders heading and passes posts to PostList

## Testing
- `npx astro check`
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6891844c2e4c83338bfd84d7ca70f80c