### PR TITLE
test: add nav component test

### DIFF
--- a/src/components/Nav.test.ts
+++ b/src/components/Nav.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { renderAstro } from '~/test-utils';
+import { load } from 'cheerio';
+
+describe('Nav', () => {
+  it('renders navigation links', async () => {
+    const html = await renderAstro('src/components/Nav.astro');
+    const $ = load(html);
+    expect($('nav.site-nav a[href="/"]').text()).toBe('Home');
+    expect($('nav.site-nav a[href="/blog"]').text()).toBe('Blog');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for Nav component ensuring Home and Blog links point to correct routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891844e92f883338777ea79c02370ae