### PR TITLE
refactor: extract render context helper

### DIFF
--- a/src/components/Landing.test.ts
+++ b/src/components/Landing.test.ts
@@ -83,7 +83,7 @@ vi.mock('~/components/RecentPosts.astro', () => {
 
 describe('Landing', () => {
   it('renders only the three most recent posts', async () => {
-    const html = await renderAstro('src/components/Landing.astro');
+    const { html } = await renderAstro('src/components/Landing.astro');
     expect(html).toContain('/blog/new/');
     expect(html).toContain('/blog/mid/');
     expect(html).toContain('/blog/old/');

--- a/src/components/PostList.test.ts
+++ b/src/components/PostList.test.ts
@@ -22,7 +22,7 @@ describe('PostList', () => {
         },
       },
     ];
-    const html = await renderAstro('src/components/PostList.astro', { posts });
+    const { html } = await renderAstro('src/components/PostList.astro', { posts });
     const $ = load(html);
     expect($('li').first().find('a').attr('href')).toBe('/blog/first/');
     expect($('li').eq(1).find('a').attr('href')).toBe('/blog/second/');

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -5,11 +5,86 @@ import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
+function createRenderContext() {
+  return {
+    // Tracks head rendering state
+    _metadata: { hasRenderedHead: false, extraHead: [] },
+    // Collected <style> tags
+    styles: new Set(),
+    // Collected <script> tags
+    scripts: new Set(),
+    // Collected <link> tags
+    links: new Set(),
+    // Builds the Astro global used by components
+    createAstro: (
+      Astro: Record<string, unknown>,
+      props: unknown,
+      slots: unknown
+    ) => ({
+      ...Astro,
+      props,
+      slots,
+    }),
+    // Resolves specifiers to final paths
+    resolve: async (s: string) => s,
+    // Mock response object
+    response: {},
+    // Mock request object
+    request: {},
+    // Registered server renderers
+    renderers: [],
+    // Client-only directive registry
+    clientDirectives: new Map(),
+    // Disable HTML compression
+    compressHTML: false,
+    // Indicates partial rendering mode
+    partial: false,
+    // Current request pathname
+    pathname: '',
+    // Cookie storage (unused in tests)
+    cookies: undefined,
+    // Maps server island component names
+    serverIslandNameMap: new Map(),
+    // Trailing slash behavior
+    trailingSlash: 'ignore',
+    // Unique key for the render
+    key: Promise.resolve({}),
+    // Destination for CSP meta tags
+    cspDestination: 'head',
+    // Whether to inject CSP meta tags
+    shouldInjectCspMetaTags: false,
+    // Algorithm used for CSP hashes
+    cspAlgorithm: '',
+    // Collected script hashes for CSP
+    scriptHashes: new Set(),
+    // External script resources
+    scriptResources: new Set(),
+    // Collected style hashes for CSP
+    styleHashes: new Set(),
+    // External style resources
+    styleResources: new Set(),
+    // User-defined directives
+    directives: new Map(),
+    // Flag for strict-dynamic CSP
+    isStrictDynamic: false,
+    // Base path for URLs
+    base: '/',
+    // Optional user asset base
+    userAssetsBase: undefined,
+    // Abort rendering early
+    cancelled: false,
+    // Metadata about rendered components
+    componentMetadata: new Map(),
+    // Inlined scripts keyed by id
+    inlinedScripts: new Map(),
+  };
+}
+
 export async function renderAstro(
   file: string,
   props: Record<string, unknown> = {},
   transformCode?: (code: string) => string
-): Promise<string> {
+): Promise<ReturnType<typeof createRenderContext> & { html: string }> {
   const source = await readFile(file, 'utf-8');
   let { code } = await transform(source, {
     filename: file,
@@ -26,47 +101,9 @@ export async function renderAstro(
   const mod = await import(pathToFileURL(tempPath).href);
   await unlink(tempPath).catch(() => {});
   const Component = mod.default;
-  const result = {
-    _metadata: { hasRenderedHead: false, extraHead: [] },
-    styles: new Set(),
-    scripts: new Set(),
-    links: new Set(),
-    createAstro: (
-      Astro: Record<string, unknown>,
-      props: unknown,
-      slots: unknown
-    ) => ({
-      ...Astro,
-      props,
-      slots,
-    }),
-    resolve: async (s: string) => s,
-    response: {},
-    request: {},
-    renderers: [],
-    clientDirectives: new Map(),
-    compressHTML: false,
-    partial: false,
-    pathname: '',
-    cookies: undefined,
-    serverIslandNameMap: new Map(),
-    trailingSlash: 'ignore',
-    key: Promise.resolve({}),
-    cspDestination: 'head',
-    shouldInjectCspMetaTags: false,
-    cspAlgorithm: '',
-    scriptHashes: new Set(),
-    scriptResources: new Set(),
-    styleHashes: new Set(),
-    styleResources: new Set(),
-    directives: new Map(),
-    isStrictDynamic: false,
-    base: '/',
-    userAssetsBase: undefined,
-    cancelled: false,
-    componentMetadata: new Map(),
-    inlinedScripts: new Map(),
-  };
+  const result = createRenderContext() as ReturnType<
+    typeof createRenderContext
+  > & { html: string };
   const html = (await (
     runtime.renderToString as unknown as (
       result: unknown,
@@ -75,5 +112,6 @@ export async function renderAstro(
       slots: unknown
     ) => Promise<string>
   )(result, Component, props, {})) as string;
-  return html;
+  result.html = html;
+  return result;
 }


### PR DESCRIPTION
## Summary
- create `createRenderContext` helper with documented fields
- return render context (with `html` property) from `renderAstro`
- adjust tests for new render helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891845433808333b80aee65575f7f40