### PR TITLE
feat: type landing posts

### DIFF
--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -6,12 +6,15 @@ import Technologies from '~/components/Technologies.astro';
 import CTA from '~/components/CTA.astro';
 import '~/styles/landing.css';
 import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 
 // Based on uploaded HTML landing content
-const allPosts = await getCollection('blog');
+const allPosts: CollectionEntry<'blog'>[] = await getCollection('blog');
 const posts = allPosts
-  // @ts-expect-error - runtime sort does not need explicit types
-  .sort((a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf())
+  .sort(
+    (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+      b.data.publishDate.valueOf() - a.data.publishDate.valueOf(),
+  )
   .slice(0, 3);
 ---
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, unlink } from 'node:fs/promises';
 import { transform } from '@astrojs/compiler';
+import { transformSync as esbuildTransform } from 'esbuild';
 import * as runtime from 'astro/runtime/server/index.js';
 import * as path from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -90,11 +91,10 @@ export async function renderAstro(
     filename: file,
     internalURL: 'astro/runtime/server/index.js',
   });
-  code = code
+  code = esbuildTransform(code, { loader: 'ts', format: 'esm' }).code
     .replace(/import type[^;]+;\n?/g, '')
-    .replace(/ as {[^}]+};/, ';')
     .replace(/,\s*createMetadata as \$\$createMetadata/, '')
-    .replace(/export const \$\$metadata[^;]+;\n/, '');
+    .replace(/const \$\$metadata[^;]+;\n/, '');
   if (transformCode) code = transformCode(code);
   const tempPath = path.join(path.dirname(file), `.tmp-${randomUUID()}.mjs`);
   await writeFile(tempPath, code, 'utf-8');


### PR DESCRIPTION
## Summary
- type Landing page collection and sort comparator
- ensure test utilities transpile TypeScript when rendering components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68921f2dcc1083339aa2f5336ebcaf6a