### PR TITLE
Ensure temporary module cleanup in test utilities

### DIFF
--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -98,8 +98,12 @@ export async function renderAstro(
   if (transformCode) code = transformCode(code);
   const tempPath = path.join(path.dirname(file), `.tmp-${randomUUID()}.mjs`);
   await writeFile(tempPath, code, 'utf-8');
-  const mod = await import(pathToFileURL(tempPath).href);
-  await unlink(tempPath).catch(() => {});
+  let mod;
+  try {
+    mod = await import(pathToFileURL(tempPath).href);
+  } finally {
+    await unlink(tempPath).catch(() => {});
+  }
   const Component = mod.default;
   const result = createRenderContext();
   const html = (await (


### PR DESCRIPTION
## Summary
- Wrap temp module import in a try/finally
- Delete temporary module file inside the finally block

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921f3a9be88333875d03e7245f9d61