### PR TITLE
Refactor RecentPosts prop typing and test

### DIFF
--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -1,10 +1,8 @@
 ---
 import PostList from '~/components/PostList.astro';
 import type { CollectionEntry } from 'astro:content';
-interface Props {
-  posts: CollectionEntry<'blog'>[];
-}
-const { posts } = Astro.props as Props;
+
+const { posts } = Astro.props as { posts: CollectionEntry<'blog'>[] };
 ---
 
 <section class="section">

--- a/src/components/RecentPosts.test.ts
+++ b/src/components/RecentPosts.test.ts
@@ -30,14 +30,7 @@ describe('RecentPosts', () => {
         },
       },
     ];
-    const html = await renderAstro(
-      'src/components/RecentPosts.astro',
-      { posts },
-      (code) =>
-        code
-          .replace(/interface Props\s*{[^}]+}\n/, '')
-          .replace(/Astro\.props as Props/, 'Astro.props')
-    );
+      const html = await renderAstro('src/components/RecentPosts.astro', { posts });
     const $ = load(html);
     expect($('h2').text()).toBe('Recent Posts');
     expect(postListStub).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary
- inline type for `RecentPosts` props so component accepts props without code transforms
- simplify `RecentPosts.test.ts` by calling `renderAstro` directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68921f441cec833384dbe3cd5ddafb20